### PR TITLE
Feat: Method Scan, Value fo fixedpoint

### DIFF
--- a/fixedpoint/fixedpoint.go
+++ b/fixedpoint/fixedpoint.go
@@ -429,6 +429,10 @@ func (f *FixedPoint) Scan(value interface{}) error {
 		f.d.Decimal = v
 		f.d.Valid = true
 		return nil
+	case decimal.NullDecimal:
+		// Directly handle decimal.NullDecimal type
+		f.d = v
+		return nil
 	default:
 		// Use the normal NullDecimal scan for other types
 		return f.d.Scan(value)


### PR DESCRIPTION
Scan
Why not using f.d.Scan directly?
- Because we have a custom type that is `fixedpoint.Fixpoint` so when the driver see our custom type it pass the `decimal.Decimal` type and if we just call `f.d.Scan` in `f.d.Scan` it only handle type of `float32`, `float64`, `int64`, `uint64`, `string (default case)` so it fall to default case that is a `string` and then it will fall to another default case in `unquoteIfQuote` function that checking the type of `string` and `[]byte` only, so it fall to another default case that return an error
![image](https://github.com/user-attachments/assets/1a417ea0-ef5f-4523-8632-c949f4638d97)

![image](https://github.com/user-attachments/assets/390703c4-8518-4075-911e-ace4f4e7a6f2)